### PR TITLE
Unifying codepaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,10 @@ addSbtPlugin("com.twilio" % "sbt-guardrail" % "<Please use the latest available 
     tracing: Boolean
 */
 guardrailTasks in Compile := List(
-  Client(file("petstore.yaml")),
-  Client(file("github.yaml"), pkg="com.example.clients.github"),
-  Server(file("myserver.yaml"), pkg="com.example.server", tracing=true),
-  Models(file("myserver.yaml"), pkg="com.example.models")
+  ScalaClient(file("petstore.yaml")),
+  ScalaClient(file("github.yaml"), pkg="com.example.clients.github"),
+  ScalaServer(file("myserver.yaml"), pkg="com.example.server", tracing=true),
+  ScalaModels(file("myserver.yaml"), pkg="com.example.models"),
+  JavaClient(file("github.yaml"), pkg="com.example.clients.github")
 )
 ```

--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ git.useGitDescribe := true
 
 // Dependencies
 resolvers += Resolver.bintrayRepo("twilio", "releases")
-libraryDependencies += "com.twilio" %% "guardrail" % "0.45.0"
+libraryDependencies += "com.twilio" %% "guardrail" % "0.45.1"
 
 // Release
 bintrayOrganization := Some("twilio")

--- a/src/main/scala/com/twilio/swagger/sbt/CodegenPlugin.scala
+++ b/src/main/scala/com/twilio/swagger/sbt/CodegenPlugin.scala
@@ -31,7 +31,6 @@ object GuardrailPlugin extends AutoPlugin {
         dtoPackage=dtoPackage.toList.flatMap(_.split('.').filterNot(_.isEmpty).toList),
         imports=imports,
         context=ContextImpl.empty.copy(
-          framework=framework.orElse(Some("akka-http")),
           tracing=tracing.getOrElse(ContextImpl.empty.tracing)
         ))
     }

--- a/src/main/scala/com/twilio/swagger/sbt/CodegenPlugin.scala
+++ b/src/main/scala/com/twilio/swagger/sbt/CodegenPlugin.scala
@@ -118,6 +118,21 @@ object GuardrailPlugin extends AutoPlugin {
       val kind = CodegenTargetImpl.Server
       val language = "scala"
     }
+
+    object JavaClient extends ClientServer {
+      val kind = CodegenTargetImpl.Client
+      val language = "java"
+    }
+
+    object JavaModels extends ClientServer {
+      val kind = CodegenTargetImpl.Models
+      val language = "java"
+    }
+
+    object JavaServer extends ClientServer {
+      val kind = CodegenTargetImpl.Server
+      val language = "java"
+    }
   }
 
   override lazy val projectSettings = Seq(

--- a/src/main/scala/com/twilio/swagger/sbt/CodegenPlugin.scala
+++ b/src/main/scala/com/twilio/swagger/sbt/CodegenPlugin.scala
@@ -86,17 +86,35 @@ object GuardrailPlugin extends AutoPlugin {
     val guardrailTasks = Keys.guardrailTasks
     val guardrail = Keys.guardrail
 
+    @deprecated("0.45.0", "Please use ScalaClient instead")
     object Client extends ClientServer {
       val kind = CodegenTargetImpl.Client
       val language = "scala"
     }
 
+    @deprecated("0.45.0", "Please use ScalaModels instead")
     object Models extends ClientServer {
       val kind = CodegenTargetImpl.Models
       val language = "scala"
     }
 
+    @deprecated("0.45.0", "Please use ScalaServer instead")
     object Server extends ClientServer {
+      val kind = CodegenTargetImpl.Server
+      val language = "scala"
+    }
+
+    object ScalaClient extends ClientServer {
+      val kind = CodegenTargetImpl.Client
+      val language = "scala"
+    }
+
+    object ScalaModels extends ClientServer {
+      val kind = CodegenTargetImpl.Models
+      val language = "scala"
+    }
+
+    object ScalaServer extends ClientServer {
       val kind = CodegenTargetImpl.Server
       val language = "scala"
     }

--- a/src/main/scala/com/twilio/swagger/sbt/CodegenPlugin.scala
+++ b/src/main/scala/com/twilio/swagger/sbt/CodegenPlugin.scala
@@ -38,6 +38,7 @@ object GuardrailPlugin extends AutoPlugin {
 
   sealed trait ClientServer {
     val kind: CodegenTargetImpl
+    val language: String
 
     def apply(
       specPath: java.io.File,
@@ -46,7 +47,7 @@ object GuardrailPlugin extends AutoPlugin {
       framework: Keys.SwaggerConfigValue[String] = Keys.Default,
       tracing: Keys.SwaggerConfigValue[Boolean] = Keys.Default,
       imports: Keys.SwaggerConfigValue[List[String]] = Keys.Default,
-    ): ArgsImpl = impl(
+    ): (Language, ArgsImpl) = (language, impl(
       kind = kind,
       specPath = Some(specPath),
       packageName = Some(pkg),
@@ -55,7 +56,7 @@ object GuardrailPlugin extends AutoPlugin {
       tracing = tracing.toOption,
       imports = imports.toOption.getOrElse(List.empty),
       defaults = false
-    )
+    ))
 
     def defaults(
       pkg: Keys.SwaggerConfigValue[String] = Keys.Default,
@@ -67,7 +68,7 @@ object GuardrailPlugin extends AutoPlugin {
       // Deprecated parameters
       packageName: Keys.SwaggerConfigValue[String] = Keys.Default,
       dtoPackage: Keys.SwaggerConfigValue[String] = Keys.Default
-    ): ArgsImpl = impl(
+    ): (Language, ArgsImpl) = (language, impl(
       kind = kind,
       specPath = None,
       packageName = pkg.toOption.orElse(packageName.toOption),
@@ -76,7 +77,7 @@ object GuardrailPlugin extends AutoPlugin {
       tracing = tracing.toOption,
       imports = imports.toOption.getOrElse(List.empty),
       defaults = true
-    )
+    ))
   }
 
 
@@ -87,14 +88,17 @@ object GuardrailPlugin extends AutoPlugin {
 
     object Client extends ClientServer {
       val kind = CodegenTargetImpl.Client
+      val language = "scala"
     }
 
     object Models extends ClientServer {
       val kind = CodegenTargetImpl.Models
+      val language = "scala"
     }
 
     object Server extends ClientServer {
       val kind = CodegenTargetImpl.Server
+      val language = "scala"
     }
   }
 
@@ -110,8 +114,7 @@ object GuardrailPlugin extends AutoPlugin {
   )
 
   type Context = ContextImpl
-  val Context = ContextImpl
 
-  type Args = ArgsImpl
-  val Args = ArgsImpl
+  type Language = String
+  type Args = (Language, ArgsImpl)
 }

--- a/src/main/scala/com/twilio/swagger/sbt/Keys.scala
+++ b/src/main/scala/com/twilio/swagger/sbt/Keys.scala
@@ -7,10 +7,6 @@ import java.net.URL
 import _root_.sbt.{ SettingKey, TaskKey }
 import scala.language.implicitConversions
 
-import com.twilio.guardrail.{
-  Args => ArgsImpl
-}
-
 object Keys {
   sealed trait SwaggerConfigValue[T] { def toOption: Option[T] }
   def Default[T]: SwaggerConfigValue[T] = SwaggerConfigValue.Default()
@@ -22,7 +18,7 @@ object Keys {
   }
 
   val guardrailDefaults = SettingKey[Args]("guardrail-defaults")
-  val guardrailTasks = SettingKey[List[ArgsImpl]]("guardrail-tasks")
+  val guardrailTasks = SettingKey[List[GuardrailPlugin.Args]]("guardrail-tasks")
   val guardrail = TaskKey[Seq[File]](
     "guardrail",
     "Generate swagger sources"

--- a/src/main/scala/com/twilio/swagger/sbt/Tasks.scala
+++ b/src/main/scala/com/twilio/swagger/sbt/Tasks.scala
@@ -29,9 +29,9 @@ object Tasks {
     val oldClassLoader = Thread.currentThread().getContextClassLoader()
     Thread.currentThread().setContextClassLoader(classOf[SwaggerParserExtension].getClassLoader)
 
-    val preppedTasks: Map[String, NonEmptyList[ArgsImpl]] = tasks.foldLeft(Map.empty[String, NonEmptyList[ArgsImpl]]) { case (acc, args) =>
+    val preppedTasks: Map[String, NonEmptyList[ArgsImpl]] = tasks.foldLeft(Map.empty[String, NonEmptyList[ArgsImpl]]) { case (acc, (language, args)) =>
       val prepped = args.copy(outputPath=Some(sourceDir.getPath))
-      acc.updated("scala", acc.get("scala").fold(NonEmptyList.one(prepped))(_ :+ prepped))
+      acc.updated(language, acc.get(language).fold(NonEmptyList.one(prepped))(_ :+ prepped))
     }
 
     val result = preppedTasks.toList.flatTraverse({ case (language, args) =>
@@ -99,7 +99,7 @@ object Tasks {
   }
 
   def watchSources(tasks: List[GuardrailPlugin.Args]): Seq[WatchSource] = {
-    tasks.flatMap(_.specPath.map(new java.io.File(_)).map(WatchSource(_))).toSeq
+    tasks.flatMap(_._2.specPath.map(new java.io.File(_)).map(WatchSource(_))).toSeq
   }
 
   private[this] def runM[L <: LA, F[_]](args: NonEmptyList[ArgsImpl])(implicit C: CoreTerms[L, F]): Free[F, NonEmptyList[ReadSwagger[Target[List[WriteTree]]]]] = {


### PR DESCRIPTION
- Switching `Client`, `Server`, `Models` to `ScalaClient`, `ScalaServer`, `ScalaModels`
- Unifying plugin code in primary guardrail codebase

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowlege that all my contributions will be made under the project's license.
