### PR TITLE
Adding framework support back in, after it was incorrectly stripped

### DIFF
--- a/src/main/scala/com/twilio/swagger/sbt/CodegenPlugin.scala
+++ b/src/main/scala/com/twilio/swagger/sbt/CodegenPlugin.scala
@@ -31,6 +31,7 @@ object GuardrailPlugin extends AutoPlugin {
         dtoPackage=dtoPackage.toList.flatMap(_.split('.').filterNot(_.isEmpty).toList),
         imports=imports,
         context=ContextImpl.empty.copy(
+          framework=framework,
           tracing=tracing.getOrElse(ContextImpl.empty.tracing)
         ))
     }


### PR DESCRIPTION
Resolving #15 twilio/guardrail#219

Entirely my mistake, from https://github.com/twilio/sbt-guardrail/commit/8a2ec52

**Contributing to Twilio**

> All third party contributors acknowledge that any contributions they provide will be made under the same open source license that the open source project is provided under.

- [x] I acknowlege that all my contributions will be made under the project's license.
