### PR TITLE
GitHub CI: enable 'cache' action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,5 +23,11 @@ jobs:
         java-version: ${{ matrix.java }}
     - name: print Java version
       run: java -version
+    - uses: actions/cache@v1.0.3
+      with:
+        path: ~/.cache/coursier
+        key: ${{ runner.os }}-scala-${{ matrix.scala }}-${{ hashFiles('**/*.sbt') }}
+        restore-keys: |
+          ${{ runner.os }}-scala-${{ matrix.scala }}-
     - name: Run tests
       run:  sbt ++${{ matrix.scala }} "^ test; scripted"


### PR DESCRIPTION
- SBT 1.3.x uses Coursier for dependency resolution
- we preserve Coursier's cache to achieve faster builds

Docs:
- https://github.com/actions/cache
- https://get-coursier.io/docs/cache

<!-- Describe your Pull Request -->

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
