### PR TITLE
clean: Fix the cache usage in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,16 +17,9 @@ branches:
 script:
 - sbt ++$TRAVIS_SCALA_VERSION clean compile
 
-# Cache configs taken from https://www.scala-sbt.org/1.0/docs/Travis-CI-with-sbt.html
-before_cache:
-  # Cleanup the cached directories to avoid unnecessary cache updates
-  - rm -fv $HOME/.ivy2/.sbt.ivy.lock
-  - find $HOME/.ivy2/cache -name "ivydata-*.properties" -print -delete
-  - find $HOME/.sbt        -name "*.lock"               -print -delete
 cache:
   directories:
-    - $HOME/.ivy2/cache
-    - $HOME/.sbt
+    - $HOME/.cache
 
 # Releasing configs taken from https://github.com/scalacenter/sbt-release-early/wiki/How-to-release-in-Travis-(CI)
 before_install:


### PR DESCRIPTION
Since Sbt 1.3 we can cache solely the coursier folder and remove the hacks.
This should help to have a more stable CI.

Succeeded here:
https://travis-ci.org/github/andreaTP/sbt-guardrail/builds/676233451

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.

cc. @blast-hardcheese 