### PR TITLE
Expose optional property configuration for encoding/decoding

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,14 +21,15 @@ addSbtPlugin("com.twilio" % "sbt-guardrail" % "<Please use the latest available 
     modules: List[String]
     tracing: Boolean
     imports: List[String]
-    propertyRequirement: PropertyRequirement.Configured
+    encodeOptionalAs: Option[CodingConfig]
+    decodeOptionalAs: Option[CodingConfig]
 */
 guardrailTasks in Compile := List(
   ScalaClient(file("petstore.yaml")),
   ScalaClient(file("github.yaml"), pkg="com.example.clients.github"),
   ScalaClient(file("github.yaml"), pkg="com.example.clients.github", 
-              propertyRequirement = PropertyRequirement.Configured(PropertyRequirement.Optional, 
-                                                                   PropertyRequirement.Optional)),
+              encodeOptionalAs = codingOptional,
+              decodeOptionalAs = codingRequiredNullable),
   ScalaServer(file("myserver.yaml"), pkg="com.example.server", tracing=true),
   ScalaModels(file("myserver.yaml"), pkg="com.example.models"),
   JavaClient(file("github.yaml"), pkg="com.example.clients.github")

--- a/README.md
+++ b/README.md
@@ -21,10 +21,14 @@ addSbtPlugin("com.twilio" % "sbt-guardrail" % "<Please use the latest available 
     modules: List[String]
     tracing: Boolean
     imports: List[String]
+    propertyRequirement: PropertyRequirement.Configured
 */
 guardrailTasks in Compile := List(
   ScalaClient(file("petstore.yaml")),
   ScalaClient(file("github.yaml"), pkg="com.example.clients.github"),
+  ScalaClient(file("github.yaml"), pkg="com.example.clients.github", 
+              propertyRequirement = PropertyRequirement.Configured(PropertyRequirement.Optional, 
+                                                                   PropertyRequirement.Optional)),
   ScalaServer(file("myserver.yaml"), pkg="com.example.server", tracing=true),
   ScalaModels(file("myserver.yaml"), pkg="com.example.models"),
   JavaClient(file("github.yaml"), pkg="com.example.clients.github")

--- a/modules/core/src/main/scala/Keys.scala
+++ b/modules/core/src/main/scala/Keys.scala
@@ -6,6 +6,21 @@ import java.io.File
 import _root_.sbt.{ SettingKey, TaskKey }
 import scala.language.implicitConversions
 
+import com.twilio.guardrail.protocol.terms.protocol.PropertyRequirement
+
+sealed trait CodingConfig {
+  def toOptionalRequirement: PropertyRequirement.OptionalRequirement = this match {
+    case CodingConfig.RequiredNullable => PropertyRequirement.RequiredNullable
+    case CodingConfig.Optional => PropertyRequirement.Optional
+    case CodingConfig.OptionalLegacy => PropertyRequirement.OptionalLegacy
+  }
+}
+object CodingConfig {
+  case object RequiredNullable extends CodingConfig
+  case object Optional extends CodingConfig
+  case object OptionalLegacy extends CodingConfig
+}
+
 object Keys {
   sealed trait SwaggerConfigValue[T] { def toOption: Option[T] }
   def Default[T]: SwaggerConfigValue[T] = SwaggerConfigValue.Default()
@@ -22,4 +37,8 @@ object Keys {
     "guardrail",
     "Generate swagger sources"
   )
+
+  def codingRequiredNullable: CodingConfig = CodingConfig.RequiredNullable
+  def codingOptional: CodingConfig = CodingConfig.Optional
+  def codingOptionalLegacy: CodingConfig = CodingConfig.OptionalLegacy
 }


### PR DESCRIPTION
<!-- Describe your Pull Request -->

In order to be able to configure how Optionals should be encoded/decoded,[ this property already available on the CLI](https://github.com/twilio/guardrail/pull/627#issuecomment-629739433) should also be available in sbt. That's what I'm doing in this PR.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
