### PR TITLE
fix: Additional imports in test

### DIFF
--- a/src/sbt-test/sbt-guardrail/scala-client-codegen-app/build.sbt
+++ b/src/sbt-test/sbt-guardrail/scala-client-codegen-app/build.sbt
@@ -7,8 +7,8 @@ scalaVersion := "2.12.10"
 scalacOptions += "-Xexperimental"
 
 guardrailTasks in Compile := List(
-  ScalaClient(file("petstore.json"), pkg="com.example.clients.petstore", imports=List("support.PositiveLong")),
-  ScalaServer(file("petstore.json"), pkg="com.example.servers.petstore", imports=List("support.PositiveLong"))
+  ScalaClient(file("petstore.json"), pkg="com.example.clients.petstore", imports=List("_root_.support.PositiveLong")),
+  ScalaServer(file("petstore.json"), pkg="com.example.servers.petstore", imports=List("_root_.support.PositiveLong"))
 )
 
 val circeVersion = "0.13.0"


### PR DESCRIPTION
This fixes the scripted tests in master.
Current error is:

```
[info] [error] /tmp/sbt_960e7da8/scala-client-codegen-app/target/scala-2.12/src_managed/main/com/example/clients/petstore/definitions/package.scala:6:8: object PositiveLong is not a member of package com.example.clients.petstore.support
[info] [error] import support.PositiveLong
[info] [error]        ^
[info] [error] /tmp/sbt_960e7da8/scala-client-codegen-app/target/scala-2.12/src_managed/main/com/example/servers/petstore/definitions/package.scala:6:8: object PositiveLong is not a member of package com.example.servers.petstore.support
[info] [error] import support.PositiveLong
[info] [error]        ^
[info] [error] two errors found
[info] [error] (Compile / compileIncremental) Compilation failed
[info] [error] Total time: 15 s, completed Jun 18, 2020 10:58:42 AM
```
adding the absolute `_root_` to the additional imports fixes it.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [X] I acknowledge that all my contributions will be made under the project's license.
