### PR TITLE
Fixing guardrail tasks in test

### DIFF
--- a/modules/core/src/main/scala/AbstractCodegenPlugin.scala
+++ b/modules/core/src/main/scala/AbstractCodegenPlugin.scala
@@ -175,9 +175,9 @@ trait AbstractGuardrailPlugin { self: AutoPlugin =>
         def calcResult() =
           GuardrailAnalysis(Tasks.guardrailTask(runner)(tasks, sources.head).toList)
 
-        val cachedResult = Tracked.lastOutput[Unit, GuardrailAnalysis](streams.cacheStoreFactory.sub(kind).make("last")) {
+        val cachedResult = Tracked.lastOutput[Unit, GuardrailAnalysis](streams.cacheStoreFactory.sub("guardrail").sub(kind).make("last")) {
           (_, prev) =>
-          val tracker = Tracked.inputChanged[String, GuardrailAnalysis](streams.cacheStoreFactory.sub(kind).make("input")) {
+          val tracker = Tracked.inputChanged[String, GuardrailAnalysis](streams.cacheStoreFactory.sub("guardrail").sub(kind).make("input")) {
             (changed: Boolean, in: String) =>
               prev match {
                 case None => calcResult()

--- a/modules/core/src/main/scala/AbstractCodegenPlugin.scala
+++ b/modules/core/src/main/scala/AbstractCodegenPlugin.scala
@@ -169,11 +169,11 @@ trait AbstractGuardrailPlugin { self: AutoPlugin =>
     }
   }
 
-  private def cachedGuardrailTask(streams: _root_.sbt.Keys.TaskStreams)(tasks: List[(String, Args)], sources: java.io.File) = {
+  private def cachedGuardrailTask(streams: _root_.sbt.Keys.TaskStreams)(tasks: List[(String, Args)], sources: Seq[java.io.File]) = {
         import _root_.sbt.util.CacheImplicits._
 
         def calcResult() =
-          GuardrailAnalysis(Tasks.guardrailTask(runner)(tasks, sources).toList)
+          GuardrailAnalysis(Tasks.guardrailTask(runner)(tasks, sources.head).toList)
 
         val cachedResult = Tracked.lastOutput[Unit, GuardrailAnalysis](streams.cacheStoreFactory.make("last")) {
           (_, prev) =>
@@ -199,8 +199,8 @@ trait AbstractGuardrailPlugin { self: AutoPlugin =>
   override lazy val projectSettings = Seq(
     Keys.guardrailTasks in Compile := List.empty,
     Keys.guardrailTasks in Test := List.empty,
-    Keys.guardrail in Compile := cachedGuardrailTask(_root_.sbt.Keys.streams.value)((Keys.guardrailTasks in Compile).value, (SbtKeys.managedSourceDirectories in Compile).value.head),
-    Keys.guardrail in Test := cachedGuardrailTask(_root_.sbt.Keys.streams.value)((Keys.guardrailTasks in Test).value, (SbtKeys.managedSourceDirectories in Test).value.head),
+    Keys.guardrail in Compile := cachedGuardrailTask(_root_.sbt.Keys.streams.value)((Keys.guardrailTasks in Compile).value, (SbtKeys.managedSourceDirectories in Compile).value),
+    Keys.guardrail in Test := cachedGuardrailTask(_root_.sbt.Keys.streams.value)((Keys.guardrailTasks in Test).value, (SbtKeys.managedSourceDirectories in Test).value),
     SbtKeys.sourceGenerators in Compile += (Keys.guardrail in Compile).taskValue,
     SbtKeys.sourceGenerators in Test += (Keys.guardrail in Test).taskValue,
     SbtKeys.watchSources in Compile ++= Tasks.watchSources((Keys.guardrailTasks in Compile).value),

--- a/modules/core/src/main/scala/AbstractCodegenPlugin.scala
+++ b/modules/core/src/main/scala/AbstractCodegenPlugin.scala
@@ -196,14 +196,14 @@ trait AbstractGuardrailPlugin { self: AutoPlugin =>
       cachedResult(()).products
   }
 
-  override lazy val projectSettings = Seq(
-    Keys.guardrailTasks in Compile := List.empty,
-    Keys.guardrailTasks in Test := List.empty,
-    Keys.guardrail in Compile := cachedGuardrailTask(_root_.sbt.Keys.streams.value)((Keys.guardrailTasks in Compile).value, (SbtKeys.managedSourceDirectories in Compile).value),
-    Keys.guardrail in Test := cachedGuardrailTask(_root_.sbt.Keys.streams.value)((Keys.guardrailTasks in Test).value, (SbtKeys.managedSourceDirectories in Test).value),
-    SbtKeys.sourceGenerators in Compile += (Keys.guardrail in Compile).taskValue,
-    SbtKeys.sourceGenerators in Test += (Keys.guardrail in Test).taskValue,
-    SbtKeys.watchSources in Compile ++= Tasks.watchSources((Keys.guardrailTasks in Compile).value),
-    SbtKeys.watchSources in Test ++= Tasks.watchSources((Keys.guardrailTasks in Test).value),
+  def scopedSettings(scope: Configuration) = Seq(
+    Keys.guardrailTasks in scope := List.empty,
+    Keys.guardrail in scope := cachedGuardrailTask(_root_.sbt.Keys.streams.value)((Keys.guardrailTasks in scope).value, (SbtKeys.managedSourceDirectories in scope).value),
+    SbtKeys.sourceGenerators in scope += (Keys.guardrail in scope).taskValue,
+    SbtKeys.watchSources in scope ++= Tasks.watchSources((Keys.guardrailTasks in scope).value),
   )
+
+  override lazy val projectSettings = {
+    scopedSettings(Compile) ++ scopedSettings(Test)
+  }
 }

--- a/src/sbt-test/sbt-guardrail/java-codegen-app/petstore.json
+++ b/src/sbt-test/sbt-guardrail/java-codegen-app/petstore.json
@@ -862,6 +862,8 @@
         "responses": {
           "200": {
             "description": "successful operation"
+          }, "302": {
+            "description": "It's a real web service and this is what they really return"
           }
         }
       }

--- a/src/sbt-test/sbt-guardrail/java-codegen-app/src/test/scala/helloworld/HelloSpec.scala
+++ b/src/sbt-test/sbt-guardrail/java-codegen-app/src/test/scala/helloworld/HelloSpec.scala
@@ -17,6 +17,6 @@ class HelloSpec extends FlatSpec
       val logoutResponse = future.get(10, TimeUnit.SECONDS)
       future.isDone shouldBe true
       future.isCompletedExceptionally shouldBe false
-      logoutResponse.getClass shouldBe classOf[LogoutUserResponse.Ok]
+      logoutResponse.getClass shouldBe classOf[LogoutUserResponse.Found]
   }
 }

--- a/src/sbt-test/sbt-guardrail/scala-client-codegen-app/build.sbt
+++ b/src/sbt-test/sbt-guardrail/scala-client-codegen-app/build.sbt
@@ -11,6 +11,11 @@ guardrailTasks in Compile := List(
   ScalaServer(file("petstore.json"), pkg="com.example.servers.petstore", imports=List("_root_.support.PositiveLong"))
 )
 
+guardrailTasks in Test := List(
+  ScalaClient(file("petstore.json"), pkg="com.example.tests.clients.petstore", imports=List("_root_.support.PositiveLong", "_root_.support.tests.PositiveLongInstances._")),
+  ScalaServer(file("petstore.json"), pkg="com.example.tests.servers.petstore", imports=List("_root_.support.PositiveLong", "_root_.support.tests.PositiveLongInstances._"))
+)
+
 val circeVersion = "0.13.0"
 
 libraryDependencies ++= Seq(

--- a/src/sbt-test/sbt-guardrail/scala-client-codegen-app/src/test/scala/helloworld/HelloSpec.scala
+++ b/src/sbt-test/sbt-guardrail/scala-client-codegen-app/src/test/scala/helloworld/HelloSpec.scala
@@ -4,6 +4,7 @@ package helloworld
 import org.scalatest._
 import cats.implicits._
 import com.example.clients.petstore.user.GetUserByNameResponse
+import com.example.tests.clients.petstore.user.{ GetUserByNameResponse => MustExist }
 import org.scalatest.concurrent.ScalaFutures
 
 import scala.concurrent.ExecutionContext.Implicits.global

--- a/src/sbt-test/sbt-guardrail/scala-client-codegen-app/src/test/scala/support/PostitiveLong.scala
+++ b/src/sbt-test/sbt-guardrail/scala-client-codegen-app/src/test/scala/support/PostitiveLong.scala
@@ -1,0 +1,9 @@
+package support.tests
+
+import _root_.support.PositiveLong
+import com.example.tests.clients.petstore.Implicits
+import io.circe.Decoder
+
+object PositiveLongInstances {
+  implicit val showable = Implicits.Show.build[PositiveLong](_.value.toString())
+}


### PR DESCRIPTION
Resolving #72 

- Constraining cache by compilation scope
- Adding a hacky fix for java `scripted` test
- Adding a test to ensure that `guardrailTasks in Test` continues to work

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
