### PR TITLE
Fixing build

### DIFF
--- a/src/sbt-test/sbt-guardrail/java-codegen-app/build.sbt
+++ b/src/sbt-test/sbt-guardrail/java-codegen-app/build.sbt
@@ -14,12 +14,14 @@ guardrailTasks in Compile := List(
 managedSourceDirectories in Compile += (sourceManaged in Compile).value
 
 val jacksonVersion = "2.10.1"
+val javaxAnnotationVersion = "1.3.2"
 
 libraryDependencies ++= Seq(
   "com.fasterxml.jackson.core"        % "jackson-databind"          % jacksonVersion,
   "com.fasterxml.jackson.datatype"    % "jackson-datatype-jdk8"     % jacksonVersion,
   "com.fasterxml.jackson.datatype"    % "jackson-datatype-jsr310"   % jacksonVersion,
   "org.asynchttpclient"               % "async-http-client"         % "2.10.4",
+  "javax.annotation"                  %  "javax.annotation-api"     % javaxAnnotationVersion, // for jdk11
   "javax.xml.bind"                    % "jaxb-api"                  % "2.3.1",
   "org.scalatest"                    %% "scalatest"                 % "3.0.8" % "test"
 )


### PR DESCRIPTION
Looks like javax.annotations became a required dependency recently, adding it to see if the build passes.

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
