### PR TITLE
Update guardrail to 0.62.1

### DIFF
--- a/modules/core/build.sbt
+++ b/modules/core/build.sbt
@@ -7,7 +7,7 @@ addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3")
 
 // Dependencies
 resolvers += Resolver.bintrayRepo("twilio", "releases")
-libraryDependencies += "com.twilio" %% "guardrail" % "0.62.0"
+libraryDependencies += "com.twilio" %% "guardrail" % "0.62.1"
 
 // Pretty disappointed this has to be copied here
 bintrayRepository := {

--- a/modules/core/build.sbt
+++ b/modules/core/build.sbt
@@ -7,7 +7,7 @@ addCompilerPlugin("org.typelevel" %% "kind-projector" % "0.10.3")
 
 // Dependencies
 resolvers += Resolver.bintrayRepo("twilio", "releases")
-libraryDependencies += "com.twilio" %% "guardrail" % "0.62.1"
+libraryDependencies += "com.twilio" %% "guardrail" % "0.62.2"
 
 // Pretty disappointed this has to be copied here
 bintrayRepository := {


### PR DESCRIPTION
Guardrail 0.62.1 solves one OAS3 bug: https://github.com/twilio/guardrail/releases/tag/v0.62.1

**Contributing to Twilio**

> All third-party contributors acknowledge that any contributions they provide will be made under the same open-source license that the open-source project is provided under.

- [x] I acknowledge that all my contributions will be made under the project's license.
